### PR TITLE
Avoid excessive rereservation on pickings during transfer

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1304,7 +1304,7 @@ class stock_picking(osv.osv):
                 #Check moves with same product
                 qty_to_assign = uom_obj._compute_qty_obj(cr, uid, ops.product_uom_id, ops.product_qty, ops.product_id.uom_id, context=context)
                 precision_rounding = ops.product_id.uom_id.rounding
-                for move_dict in prod2move_ids.get(ops.product_id.id, []):
+                for move_dict in prod2move_ids.get(ops.product_id.id, [])[:]:
                     move = move_dict['move']
                     for quant in move.reserved_quant_ids:
                         if float_compare(qty_to_assign, 0, precision_rounding=precision_rounding) != 1:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

As function _create_link_for_quant modifies variable prod2move_ids, the for does not loop on the correct items.
It sometimes implies that the variable need_rereserve is set to True, and that the picking will be rereserved during the transfer operation.
This can create a huge waste of time, and destroy old reservations which were set by the user.
